### PR TITLE
Fix template instance variable error

### DIFF
--- a/templates/nrpe.cfg.erb
+++ b/templates/nrpe.cfg.erb
@@ -246,6 +246,6 @@ command[check_swap]=<%= @libpath %>/nagios/plugins/check_swap $ARG1$
 <% end -%>
 
 # custom commands
-<% @service_check_command.each_pair do |@name, @command| -%>
-command[<%= @name %>]=<%= @command %>
+<% @service_check_command.each_pair do |name, command| -%>
+command[<%= name %>]=<%= command %>
 <% end -%>


### PR DESCRIPTION
Received the following error without making this patch to the template.

Aug  8 23:01:34 puppet puppet-master[4575]: /etc/puppet/modules/nrpe/templates/nrpe.cfg.erb:249: formal argument cannot be an instance variable
Aug  8 23:01:34 puppet puppet-master[4575]: ;  @service_check_command.each_pair do |@name, @command|
